### PR TITLE
update the green test case image color to red - this should break the ci

### DIFF
--- a/.imageTests/colors/green/green.json
+++ b/.imageTests/colors/green/green.json
@@ -2,6 +2,6 @@
   {
     "width": 100,
     "height": 100,
-    "color": "#00FF00"
+    "color": "#FF0000"
   }
 ]


### PR DESCRIPTION
Example PR which breaks the CI.

This causes the CI to break because the images generated via the green.json file does not match the reference image...